### PR TITLE
Relax regexp to allow comment within require calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,13 +57,16 @@ module.exports = function (fn, options) {
         }
 
         var webpackRequireName = wrapperSignature[1];
-        if (wrapperFuncString.indexOf(webpackRequireName + '(' + webworkifyWebpackModuleId + ')') > -1) {
+        var isWebworkifyWebpackRequired = wrapperFuncString.match(
+            new RegExp(quoteRegExp(webpackRequireName) + '\\((/\\*.*?\\*/)?\\s*' + quoteRegExp(webworkifyWebpackModuleId) + '\\s*\\)', 'g')
+        );
+        if (isWebworkifyWebpackRequired) {
             // find all calls that look like __webpack_require__(\d+), and aren't webworkify-webpack
-            var re = new RegExp(quoteRegExp(webpackRequireName) + '\\((\\d+)\\)', 'g');
+            var re = new RegExp(quoteRegExp(webpackRequireName) + '\\((/\\*.*?\\*/)?\\s*(\\d+)\\s*\\)', 'g');
             var match;
             while (match = re.exec(wrapperFuncString)) {
-                if (match[1] != ('' + webworkifyWebpackModuleId)) {
-                    potentialFnModuleIds.push(match[1]);
+                if (match[2] != ('' + webworkifyWebpackModuleId)) {
+                    potentialFnModuleIds.push(match[2]);
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webworkify-webpack-dropin",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "launch a web worker that can require() in the browser with webpack, compatible with webworkify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
With certain configurations of Webpack 2.2.1, webpack require calls are ending up having a comment before the moduleId. (e.g. `__webpack_require__(/*! webworkify */ 2107)`). This change handles both commented and non-commented versions of webpack require calls. @Ambroos wdyt?